### PR TITLE
fix: disable the output stream to prevent the code 23 error

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -146,7 +146,7 @@ jobs:
         run: |
             # Run curl 20 times with a retry delay of 15 seconds. 
             # For success it will exit with the code 0, and for failure with the code 6.
-            curl --retry 20 --retry-delay 15 -s -o /dev/null "https://${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev${{ inputs.path }}"
+            curl --retry 20 --retry-delay 15 -N -s -o /dev/null "https://${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev${{ inputs.path }}"
 
       # === Create a GitHub IAT token for the Dignio app.
       # This is kind of stupid because the only reason we're doing

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -146,7 +146,7 @@ jobs:
         run: |
             # Run curl 20 times with a retry delay of 15 seconds. 
             # For success it will exit with the code 0, and for failure with the code 6.
-            curl --retry 20 --retry-delay 15 -N -s -o /dev/null "https://${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev${{ inputs.path }}"
+            curl --retry 20 --retry-delay 15 --no-buffer --silent --output /dev/null "https://${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev${{ inputs.path }}"
 
       # === Create a GitHub IAT token for the Dignio app.
       # This is kind of stupid because the only reason we're doing


### PR DESCRIPTION
Example failing workflow: https://github.com/dignio/prevent-ui/runs/5048981980\?check_suite_focus\=true

This happens now and then, and stackoverflow suggests to add the -N to disable the buffer for output stream to solve this. 🤞 