### PR TITLE
PLAT-451: Make dual workflow preview work

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -187,7 +187,7 @@ jobs:
         with:
           name: "${{ steps.app_name.outputs.full_name }} deploy preview"
           description: Deploy Preview ready! Click Details to browse to it.
-          context: Preview
+          context: Preview ${{ steps.app_name.outputs.full_name }}
           owner: dignio
           repo: ${{ inputs.app_name }}
           state: success

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -69,8 +69,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      # ===  Check out utilities folder from dignio/workflows
-      - name: Checkout repository
+      # ===  Check out dignio workflow repo for the utilities folder
+      - name: Checkout dignio/workflow repository
         uses: actions/checkout@v2
         with:
           repository: dignio/workflows
@@ -206,6 +206,14 @@ jobs:
     if: github.event.action == 'closed'
     runs-on: ubuntu-latest
     steps:
+      # ===  Check out dignio workflow repo for the utilities folder
+      - name: Checkout dignio/workflow repository
+        uses: actions/checkout@v2
+        with:
+          repository: dignio/workflows
+          ref: "PLAT-451/dual-workflow-preview"
+          path: ".dignio-workflows"
+
       # === github.head_ref has to be used to get the branch name while in PR state
       - name: Branch name to URL friendly string
         uses: dignio/letter-case-action@v1
@@ -216,13 +224,7 @@ jobs:
       # === Create the full app name for docker images and manifests
       - name: Create full app name
         id: app_name
-        run: |
-          full_app_name="${{ inputs.app_name }}"
-
-          # Prepend the postfix if it exists
-          [[ ! -z "${{ inputs.app_name_postfix}}" ]] && full_app_name+="-${{ inputs.app_name_postfix}}"
-
-          echo "::set-output name=full_name::$full_app_name"
+        run: bash .dignio-workflows/utilities/create-full-app-name.sh ${{ inputs.app_name }} ${{ inputs.app_name_postfix}}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -18,6 +18,10 @@ on:
         type: number
 
       # Optional inputs goes here
+      app_name_postfix:
+        description: Postfix the app name if this workflow is being used for different things. I.e. two different docker builds.
+        required: false
+        type: string
       docker_build_args:
         description: By using this you can add multi line build args to docker
         required: false
@@ -108,10 +112,10 @@ jobs:
       - name: Deploy the service to Kubernetes
         uses: dignio/deploy-service@v2
         with:
-          app_name: ${{ inputs.app_name }}-${{ steps.letter_case.outputs.kebab }}-preview
+          app_name: ${{ inputs.app_name }}-${{ inputs.app_name_postfix}}-${{ steps.letter_case.outputs.kebab }}-preview
           service_type: ${{ inputs.service_type }}
           namespace: ${{ env.NAMESPACE }}
-          docker_image: ${{ steps.login-ecr.outputs.registry }}/${{ inputs.app_name }}:${{ env.INSTANCE }}-${{ steps.letter_case.outputs.kebab }}-preview-${{ steps.short_id.outputs.sha }}
+          docker_image: ${{ steps.login-ecr.outputs.registry }}/${{ inputs.app_name }}:${{ env.INSTANCE }}-${{ inputs.app_name_postfix}}-${{ steps.letter_case.outputs.kebab }}-preview-${{ steps.short_id.outputs.sha }}
           aws_region: ${{ env.REGION }}
           replicas: 1
           port: ${{ inputs.port }}
@@ -135,14 +139,14 @@ jobs:
       - name: Add the service to the preview ingress
         shell: bash
         run: |
-          EXIST=$(${{ steps.kubectl.outputs.kubectl-path }} get ingress preview-ingress --namespace=${{ env.NAMESPACE }} --output=json  | jq '.spec.rules | map(.host == "${{ inputs.app_name }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev") | index(true)')
+          EXIST=$(${{ steps.kubectl.outputs.kubectl-path }} get ingress preview-ingress --namespace=${{ env.NAMESPACE }} --output=json  | jq '.spec.rules | map(.host == "${{ inputs.app_name }}-${{ inputs.app_name_postfix}}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev") | index(true)')
 
           # If the preview ingress does not have the host name, add it.
           if [ "$EXIST" == "null" ] 
           then 
             echo "Creating a preview URL."
 
-            ${{ steps.kubectl.outputs.kubectl-path }} patch ingress preview-ingress --namespace=${{ env.NAMESPACE }} --type='json' -p='[ { "op":"add","path":"/spec/rules/-", "value": { "host": "${{ inputs.app_name }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev", "http": { "paths": [ { "backend": { "service": { "name": "${{ inputs.app_name }}-${{ steps.letter_case.outputs.kebab }}-preview", "port": { "number": ${{ inputs.port }} } } }, "path": "${{ inputs.path }}", "pathType": "Prefix" } ] } } } ]'
+            ${{ steps.kubectl.outputs.kubectl-path }} patch ingress preview-ingress --namespace=${{ env.NAMESPACE }} --type='json' -p='[ { "op":"add","path":"/spec/rules/-", "value": { "host": "${{ inputs.app_name }}-${{ inputs.app_name_postfix}}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev", "http": { "paths": [ { "backend": { "service": { "name": "${{ inputs.app_name }}-${{ inputs.app_name_postfix}}-${{ steps.letter_case.outputs.kebab }}-preview", "port": { "number": ${{ inputs.port }} } } }, "path": "${{ inputs.path }}", "pathType": "Prefix" } ] } } } ]'
           else 
             echo "Preview URL already exists. Skipping." 
           fi
@@ -152,7 +156,7 @@ jobs:
         run: |
             # Run curl 20 times with a retry delay of 15 seconds. 
             # For success it will exit with the code 0, and for failure with the code 6.
-            curl --retry 20 --retry-delay 15 --no-buffer --silent --output /dev/null "https://${{ inputs.app_name }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev${{ inputs.path }}"
+            curl --retry 20 --retry-delay 15 --no-buffer --silent --output /dev/null "https://${{ inputs.app_name }}-${{ inputs.app_name_postfix}}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev${{ inputs.path }}"
 
       # === Create a GitHub IAT token for the Dignio app.
       # This is kind of stupid because the only reason we're doing
@@ -170,7 +174,7 @@ jobs:
         uses: octokit/request-action@v2.x
         id: create_commit_status
         with:
-          name: "${{ inputs.app_name }} deploy preview"
+          name: "${{ inputs.app_name }}-${{ inputs.app_name_postfix}} deploy preview"
           description: Deploy Preview ready! Click Details to browse to it.
           context: Preview
           owner: dignio
@@ -178,7 +182,7 @@ jobs:
           state: success
           accept: application/vnd.github.v3+json
           route: POST /repos/{owner}/{repo}/statuses/{sha}
-          target_url: https://${{ inputs.app_name }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev
+          target_url: https://${{ inputs.app_name }}-${{ inputs.app_name_postfix}}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev
           sha: ${{ github.event.pull_request.head.sha }}
         env:
           GITHUB_TOKEN: ${{ steps.create-iat.outputs.token }}
@@ -218,7 +222,7 @@ jobs:
       # === This will delete all resources connected to the preview deployment
       - name: Delete the deployment and service
         shell: bash
-        run: ${{ steps.kubectl.outputs.kubectl-path }} delete deployments,services,cm,pv,pvc,sc,secrets -l app=${{ inputs.app_name }}-${{ steps.letter_case.outputs.kebab }}-preview --namespace=${{ env.NAMESPACE }}
+        run: ${{ steps.kubectl.outputs.kubectl-path }} delete deployments,services,cm,pv,pvc,sc,secrets -l app=${{ inputs.app_name }}-${{ inputs.app_name_postfix}}-${{ steps.letter_case.outputs.kebab }}-preview --namespace=${{ env.NAMESPACE }}
 
       # === This will run a kubectl request to 
       # 1. fetch the index of the preview host
@@ -226,7 +230,7 @@ jobs:
       - name: Remove the host from the preview ingress
         shell: bash
         run: |
-          INDEX=$(${{ steps.kubectl.outputs.kubectl-path }} get ingress preview-ingress --namespace=${{ env.NAMESPACE }} --output=json  | jq '.spec.rules | map(.host == "${{ inputs.app_name }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev") | index(true)')
+          INDEX=$(${{ steps.kubectl.outputs.kubectl-path }} get ingress preview-ingress --namespace=${{ env.NAMESPACE }} --output=json  | jq '.spec.rules | map(.host == "${{ inputs.app_name }}-${{ inputs.app_name_postfix}}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev") | index(true)')
 
           if [ "$INDEX" != "null" ] 
           then 

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -189,7 +189,7 @@ jobs:
         with:
           name: "${{ steps.app_name.outputs.full_name }} deploy preview"
           description: Deploy Preview ready! Click Details to browse to it.
-          context: "Preview: ${{ steps.app_name.outputs.full_name }}"
+          context: "Preview - ${{ steps.app_name.outputs.full_name }}"
           owner: dignio
           repo: ${{ inputs.app_name }}
           state: success

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -187,7 +187,7 @@ jobs:
         with:
           name: "${{ steps.app_name.outputs.full_name }} deploy preview"
           description: Deploy Preview ready! Click Details to browse to it.
-          context: Preview ${{ steps.app_name.outputs.full_name }}
+          context: "Preview: ${{ steps.app_name.outputs.full_name }}"
           owner: dignio
           repo: ${{ inputs.app_name }}
           state: success

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -22,6 +22,11 @@ on:
         description: By using this you can add multi line build args to docker
         required: false
         type: string
+      dockerfile:
+        description: The path to your dockerfile. Defaults to Dockerfile.
+        required: false
+        type: string
+        default: Dockerfile
       path:
         description: This is the index route to the application.
         required: false
@@ -91,6 +96,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ inputs.app_name }}
         with:
+          file: ${{ inputs.dockerfile }}
           push: true
           cache-from: type=registry,ref=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.letter_case.outputs.kebab }}-preview-latest
           cache-to: type=inline

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -36,7 +36,7 @@ on:
         required: false
         type: string
         default: /
-  
+
     # Secrets
     secrets:
       aws_access_key_id:
@@ -69,6 +69,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      # ===  Check out utilities folder from dignio/workflows
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          repository: dignio/workflows
+          ref: "PLAT-451/dual-workflow-preview"
+          path: ".dignio-workflows"
+
       # ===  Get the latest git short sha
       - name: Get the git short id
         id: short_id
@@ -79,13 +87,7 @@ jobs:
       # === Create the full app name for docker images and manifests
       - name: Create full app name
         id: app_name
-        run: |
-          full_app_name="${{ inputs.app_name }}"
-
-          # Prepend the postfix if it exists
-          [[ ! -z "${{ inputs.app_name_postfix}}" ]] && full_app_name+="-${{ inputs.app_name_postfix}}"
-
-          echo "::set-output name=full_name::$full_app_name"
+        run: bash .dignio-workflows/utilities/create-full-app-name.sh ${{ inputs.app_name }} ${{ inputs.app_name_postfix}}
 
       # === github.head_ref has to be used to get the branch name while in PR state
       - name: Branch name to URL friendly string
@@ -144,7 +146,7 @@ jobs:
           version: "latest"
         id: kubectl
 
-      # === This will run a kubectl request to 
+      # === This will run a kubectl request to
       # 1. fetch the index of the preview host to check the existence
       # 2. if the host do not exist, patch the ingress with the new host
       - name: Add the service to the preview ingress
@@ -153,19 +155,19 @@ jobs:
           EXIST=$(${{ steps.kubectl.outputs.kubectl-path }} get ingress preview-ingress --namespace=${{ env.NAMESPACE }} --output=json  | jq '.spec.rules | map(.host == "${{ steps.app_name.outputs.full_name }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev") | index(true)')
 
           # If the preview ingress does not have the host name, add it.
-          if [ "$EXIST" == "null" ] 
-          then 
+          if [ "$EXIST" == "null" ]
+          then
             echo "Creating a preview URL."
 
             ${{ steps.kubectl.outputs.kubectl-path }} patch ingress preview-ingress --namespace=${{ env.NAMESPACE }} --type='json' -p='[ { "op":"add","path":"/spec/rules/-", "value": { "host": "${{ steps.app_name.outputs.full_name }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev", "http": { "paths": [ { "backend": { "service": { "name": "${{ steps.app_name.outputs.full_name }}-${{ steps.letter_case.outputs.kebab }}-preview", "port": { "number": ${{ inputs.port }} } } }, "path": "${{ inputs.path }}", "pathType": "Prefix" } ] } } } ]'
-          else 
-            echo "Preview URL already exists. Skipping." 
+          else
+            echo "Preview URL already exists. Skipping."
           fi
 
       - name: Check if the preview URL is ready
         shell: bash
         run: |
-            # Run curl 20 times with a retry delay of 15 seconds. 
+            # Run curl 20 times with a retry delay of 15 seconds.
             # For success it will exit with the code 0, and for failure with the code 6.
             curl --retry 20 --retry-delay 15 --no-buffer --silent --output /dev/null "https://${{ steps.app_name.outputs.full_name }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev${{ inputs.path }}"
 
@@ -246,7 +248,7 @@ jobs:
         shell: bash
         run: ${{ steps.kubectl.outputs.kubectl-path }} delete deployments,services,cm,pv,pvc,sc,secrets -l app=${{ steps.app_name.outputs.full_name }}-${{ steps.letter_case.outputs.kebab }}-preview --namespace=${{ env.NAMESPACE }}
 
-      # === This will run a kubectl request to 
+      # === This will run a kubectl request to
       # 1. fetch the index of the preview host
       # 2. patch the ingress with what host to remove based on the index
       - name: Remove the host from the preview ingress
@@ -254,8 +256,8 @@ jobs:
         run: |
           INDEX=$(${{ steps.kubectl.outputs.kubectl-path }} get ingress preview-ingress --namespace=${{ env.NAMESPACE }} --output=json  | jq '.spec.rules | map(.host == "${{ steps.app_name.outputs.full_name }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev") | index(true)')
 
-          if [ "$INDEX" != "null" ] 
-          then 
+          if [ "$INDEX" != "null" ]
+          then
             echo "Deleting host from preview ingress."
 
             ${{ steps.kubectl.outputs.kubectl-path }} patch ingress preview-ingress --namespace=${{ env.NAMESPACE }} --type='json' -p='[ { "op":"remove","path":"/spec/rules/'"$INDEX"'" } ]'

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -102,12 +102,12 @@ jobs:
         with:
           file: ${{ inputs.dockerfile }}
           push: true
-          cache-from: type=registry,ref=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ steps.letter_case.outputs.kebab }}-preview-latest
+          cache-from: type=registry,ref=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.INSTANCE }}-${{ inputs.app_name_postfix}}-${{ steps.letter_case.outputs.kebab }}-preview-latest
           cache-to: type=inline
           build-args: ${{ inputs.docker_build_args }}
           tags: |
-            ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.INSTANCE }}-${{ steps.letter_case.outputs.kebab }}-preview-latest
-            ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.INSTANCE }}-${{ steps.letter_case.outputs.kebab }}-preview-${{ steps.short_id.outputs.sha }}
+            ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.INSTANCE }}-${{ inputs.app_name_postfix}}-${{ steps.letter_case.outputs.kebab }}-preview-latest
+            ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.INSTANCE }}-${{ inputs.app_name_postfix}}-${{ steps.letter_case.outputs.kebab }}-preview-${{ steps.short_id.outputs.sha }}
 
       - name: Deploy the service to Kubernetes
         uses: dignio/deploy-service@v2

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -74,7 +74,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: dignio/workflows
-          ref: "PLAT-451/dual-workflow-preview"
           path: ".dignio-workflows"
 
       # ===  Get the latest git short sha
@@ -211,7 +210,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: dignio/workflows
-          ref: "PLAT-451/dual-workflow-preview"
           path: ".dignio-workflows"
 
       # === github.head_ref has to be used to get the branch name while in PR state

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -85,7 +85,7 @@ jobs:
           # Prepend the postfix if it exists
           [[ ! -z "${{ inputs.app_name_postfix}}" ]] && full_app_name+="-${{ inputs.app_name_postfix}}"
 
-          echo "::set-output name=full::$full_app_name"
+          echo "::set-output name=full_name::$full_app_name"
 
       # === github.head_ref has to be used to get the branch name while in PR state
       - name: Branch name to URL friendly string
@@ -123,7 +123,7 @@ jobs:
       - name: Deploy the service to Kubernetes
         uses: dignio/deploy-service@v2
         with:
-          app_name: ${{ steps.app_name.full }}-${{ steps.letter_case.outputs.kebab }}-preview
+          app_name: ${{ steps.app_name.outputs.full_name }}-${{ steps.letter_case.outputs.kebab }}-preview
           service_type: ${{ inputs.service_type }}
           namespace: ${{ env.NAMESPACE }}
           docker_image: ${{ steps.login-ecr.outputs.registry }}/${{ inputs.app_name }}:${{ env.INSTANCE }}-${{ inputs.app_name_postfix}}-${{ steps.letter_case.outputs.kebab }}-preview-${{ steps.short_id.outputs.sha }}
@@ -150,14 +150,14 @@ jobs:
       - name: Add the service to the preview ingress
         shell: bash
         run: |
-          EXIST=$(${{ steps.kubectl.outputs.kubectl-path }} get ingress preview-ingress --namespace=${{ env.NAMESPACE }} --output=json  | jq '.spec.rules | map(.host == "${{ steps.app_name.full }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev") | index(true)')
+          EXIST=$(${{ steps.kubectl.outputs.kubectl-path }} get ingress preview-ingress --namespace=${{ env.NAMESPACE }} --output=json  | jq '.spec.rules | map(.host == "${{ steps.app_name.outputs.full_name }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev") | index(true)')
 
           # If the preview ingress does not have the host name, add it.
           if [ "$EXIST" == "null" ] 
           then 
             echo "Creating a preview URL."
 
-            ${{ steps.kubectl.outputs.kubectl-path }} patch ingress preview-ingress --namespace=${{ env.NAMESPACE }} --type='json' -p='[ { "op":"add","path":"/spec/rules/-", "value": { "host": "${{ steps.app_name.full }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev", "http": { "paths": [ { "backend": { "service": { "name": "${{ steps.app_name.full }}-${{ steps.letter_case.outputs.kebab }}-preview", "port": { "number": ${{ inputs.port }} } } }, "path": "${{ inputs.path }}", "pathType": "Prefix" } ] } } } ]'
+            ${{ steps.kubectl.outputs.kubectl-path }} patch ingress preview-ingress --namespace=${{ env.NAMESPACE }} --type='json' -p='[ { "op":"add","path":"/spec/rules/-", "value": { "host": "${{ steps.app_name.outputs.full_name }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev", "http": { "paths": [ { "backend": { "service": { "name": "${{ steps.app_name.outputs.full_name }}-${{ steps.letter_case.outputs.kebab }}-preview", "port": { "number": ${{ inputs.port }} } } }, "path": "${{ inputs.path }}", "pathType": "Prefix" } ] } } } ]'
           else 
             echo "Preview URL already exists. Skipping." 
           fi
@@ -167,7 +167,7 @@ jobs:
         run: |
             # Run curl 20 times with a retry delay of 15 seconds. 
             # For success it will exit with the code 0, and for failure with the code 6.
-            curl --retry 20 --retry-delay 15 --no-buffer --silent --output /dev/null "https://${{ steps.app_name.full }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev${{ inputs.path }}"
+            curl --retry 20 --retry-delay 15 --no-buffer --silent --output /dev/null "https://${{ steps.app_name.outputs.full_name }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev${{ inputs.path }}"
 
       # === Create a GitHub IAT token for the Dignio app.
       # This is kind of stupid because the only reason we're doing
@@ -185,7 +185,7 @@ jobs:
         uses: octokit/request-action@v2.x
         id: create_commit_status
         with:
-          name: "${{ steps.app_name.full }} deploy preview"
+          name: "${{ steps.app_name.outputs.full_name }} deploy preview"
           description: Deploy Preview ready! Click Details to browse to it.
           context: Preview
           owner: dignio
@@ -193,7 +193,7 @@ jobs:
           state: success
           accept: application/vnd.github.v3+json
           route: POST /repos/{owner}/{repo}/statuses/{sha}
-          target_url: https://${{ steps.app_name.full }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev
+          target_url: https://${{ steps.app_name.outputs.full_name }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev
           sha: ${{ github.event.pull_request.head.sha }}
         env:
           GITHUB_TOKEN: ${{ steps.create-iat.outputs.token }}
@@ -220,7 +220,7 @@ jobs:
           # Prepend the postfix if it exists
           [[ ! -z "${{ inputs.app_name_postfix}}" ]] && full_app_name+="-${{ inputs.app_name_postfix}}"
 
-          echo "::set-output name=full::$full_app_name"
+          echo "::set-output name=full_name::$full_app_name"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -244,7 +244,7 @@ jobs:
       # === This will delete all resources connected to the preview deployment
       - name: Delete the deployment and service
         shell: bash
-        run: ${{ steps.kubectl.outputs.kubectl-path }} delete deployments,services,cm,pv,pvc,sc,secrets -l app=${{ steps.app_name.full }}-${{ steps.letter_case.outputs.kebab }}-preview --namespace=${{ env.NAMESPACE }}
+        run: ${{ steps.kubectl.outputs.kubectl-path }} delete deployments,services,cm,pv,pvc,sc,secrets -l app=${{ steps.app_name.outputs.full_name }}-${{ steps.letter_case.outputs.kebab }}-preview --namespace=${{ env.NAMESPACE }}
 
       # === This will run a kubectl request to 
       # 1. fetch the index of the preview host
@@ -252,7 +252,7 @@ jobs:
       - name: Remove the host from the preview ingress
         shell: bash
         run: |
-          INDEX=$(${{ steps.kubectl.outputs.kubectl-path }} get ingress preview-ingress --namespace=${{ env.NAMESPACE }} --output=json  | jq '.spec.rules | map(.host == "${{ steps.app_name.full }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev") | index(true)')
+          INDEX=$(${{ steps.kubectl.outputs.kubectl-path }} get ingress preview-ingress --namespace=${{ env.NAMESPACE }} --output=json  | jq '.spec.rules | map(.host == "${{ steps.app_name.outputs.full_name }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev") | index(true)')
 
           if [ "$INDEX" != "null" ] 
           then 

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -76,6 +76,17 @@ jobs:
           sha=$(cut -c 1-7 <<< $GITHUB_SHA)
           echo "::set-output name=sha::$sha"
 
+      # === Create the full app name for docker images and manifests
+      - name: Create full app name
+        id: app_name
+        run: |
+          full_app_name="${{ inputs.app_name }}"
+
+          # Prepend the postfix if it exists
+          [[ ! -z "${{ inputs.app_name_postfix}}" ]] && full_app_name+="-${{ inputs.app_name_postfix}}"
+
+          echo "::set-output name=full::$full_app_name"
+
       # === github.head_ref has to be used to get the branch name while in PR state
       - name: Branch name to URL friendly string
         uses: dignio/letter-case-action@v1
@@ -112,7 +123,7 @@ jobs:
       - name: Deploy the service to Kubernetes
         uses: dignio/deploy-service@v2
         with:
-          app_name: ${{ inputs.app_name }}-${{ inputs.app_name_postfix}}-${{ steps.letter_case.outputs.kebab }}-preview
+          app_name: ${{ steps.app_name.full }}-${{ steps.letter_case.outputs.kebab }}-preview
           service_type: ${{ inputs.service_type }}
           namespace: ${{ env.NAMESPACE }}
           docker_image: ${{ steps.login-ecr.outputs.registry }}/${{ inputs.app_name }}:${{ env.INSTANCE }}-${{ inputs.app_name_postfix}}-${{ steps.letter_case.outputs.kebab }}-preview-${{ steps.short_id.outputs.sha }}
@@ -139,14 +150,14 @@ jobs:
       - name: Add the service to the preview ingress
         shell: bash
         run: |
-          EXIST=$(${{ steps.kubectl.outputs.kubectl-path }} get ingress preview-ingress --namespace=${{ env.NAMESPACE }} --output=json  | jq '.spec.rules | map(.host == "${{ inputs.app_name }}-${{ inputs.app_name_postfix}}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev") | index(true)')
+          EXIST=$(${{ steps.kubectl.outputs.kubectl-path }} get ingress preview-ingress --namespace=${{ env.NAMESPACE }} --output=json  | jq '.spec.rules | map(.host == "${{ steps.app_name.full }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev") | index(true)')
 
           # If the preview ingress does not have the host name, add it.
           if [ "$EXIST" == "null" ] 
           then 
             echo "Creating a preview URL."
 
-            ${{ steps.kubectl.outputs.kubectl-path }} patch ingress preview-ingress --namespace=${{ env.NAMESPACE }} --type='json' -p='[ { "op":"add","path":"/spec/rules/-", "value": { "host": "${{ inputs.app_name }}-${{ inputs.app_name_postfix}}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev", "http": { "paths": [ { "backend": { "service": { "name": "${{ inputs.app_name }}-${{ inputs.app_name_postfix}}-${{ steps.letter_case.outputs.kebab }}-preview", "port": { "number": ${{ inputs.port }} } } }, "path": "${{ inputs.path }}", "pathType": "Prefix" } ] } } } ]'
+            ${{ steps.kubectl.outputs.kubectl-path }} patch ingress preview-ingress --namespace=${{ env.NAMESPACE }} --type='json' -p='[ { "op":"add","path":"/spec/rules/-", "value": { "host": "${{ steps.app_name.full }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev", "http": { "paths": [ { "backend": { "service": { "name": "${{ steps.app_name.full }}-${{ steps.letter_case.outputs.kebab }}-preview", "port": { "number": ${{ inputs.port }} } } }, "path": "${{ inputs.path }}", "pathType": "Prefix" } ] } } } ]'
           else 
             echo "Preview URL already exists. Skipping." 
           fi
@@ -156,7 +167,7 @@ jobs:
         run: |
             # Run curl 20 times with a retry delay of 15 seconds. 
             # For success it will exit with the code 0, and for failure with the code 6.
-            curl --retry 20 --retry-delay 15 --no-buffer --silent --output /dev/null "https://${{ inputs.app_name }}-${{ inputs.app_name_postfix}}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev${{ inputs.path }}"
+            curl --retry 20 --retry-delay 15 --no-buffer --silent --output /dev/null "https://${{ steps.app_name.full }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev${{ inputs.path }}"
 
       # === Create a GitHub IAT token for the Dignio app.
       # This is kind of stupid because the only reason we're doing
@@ -174,7 +185,7 @@ jobs:
         uses: octokit/request-action@v2.x
         id: create_commit_status
         with:
-          name: "${{ inputs.app_name }}-${{ inputs.app_name_postfix}} deploy preview"
+          name: "${{ steps.app_name.full }} deploy preview"
           description: Deploy Preview ready! Click Details to browse to it.
           context: Preview
           owner: dignio
@@ -182,7 +193,7 @@ jobs:
           state: success
           accept: application/vnd.github.v3+json
           route: POST /repos/{owner}/{repo}/statuses/{sha}
-          target_url: https://${{ inputs.app_name }}-${{ inputs.app_name_postfix}}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev
+          target_url: https://${{ steps.app_name.full }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev
           sha: ${{ github.event.pull_request.head.sha }}
         env:
           GITHUB_TOKEN: ${{ steps.create-iat.outputs.token }}
@@ -199,6 +210,17 @@ jobs:
         id: letter_case
         with:
           string: ${{ github.head_ref }}
+
+      # === Create the full app name for docker images and manifests
+      - name: Create full app name
+        id: app_name
+        run: |
+          full_app_name="${{ inputs.app_name }}"
+
+          # Prepend the postfix if it exists
+          [[ ! -z "${{ inputs.app_name_postfix}}" ]] && full_app_name+="-${{ inputs.app_name_postfix}}"
+
+          echo "::set-output name=full::$full_app_name"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -222,7 +244,7 @@ jobs:
       # === This will delete all resources connected to the preview deployment
       - name: Delete the deployment and service
         shell: bash
-        run: ${{ steps.kubectl.outputs.kubectl-path }} delete deployments,services,cm,pv,pvc,sc,secrets -l app=${{ inputs.app_name }}-${{ inputs.app_name_postfix}}-${{ steps.letter_case.outputs.kebab }}-preview --namespace=${{ env.NAMESPACE }}
+        run: ${{ steps.kubectl.outputs.kubectl-path }} delete deployments,services,cm,pv,pvc,sc,secrets -l app=${{ steps.app_name.full }}-${{ steps.letter_case.outputs.kebab }}-preview --namespace=${{ env.NAMESPACE }}
 
       # === This will run a kubectl request to 
       # 1. fetch the index of the preview host
@@ -230,7 +252,7 @@ jobs:
       - name: Remove the host from the preview ingress
         shell: bash
         run: |
-          INDEX=$(${{ steps.kubectl.outputs.kubectl-path }} get ingress preview-ingress --namespace=${{ env.NAMESPACE }} --output=json  | jq '.spec.rules | map(.host == "${{ inputs.app_name }}-${{ inputs.app_name_postfix}}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev") | index(true)')
+          INDEX=$(${{ steps.kubectl.outputs.kubectl-path }} get ingress preview-ingress --namespace=${{ env.NAMESPACE }} --output=json  | jq '.spec.rules | map(.host == "${{ steps.app_name.full }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev") | index(true)')
 
           if [ "$INDEX" != "null" ] 
           then 

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -135,14 +135,14 @@ jobs:
       - name: Add the service to the preview ingress
         shell: bash
         run: |
-          EXIST=$(${{ steps.kubectl.outputs.kubectl-path }} get ingress preview-ingress --namespace=${{ env.NAMESPACE }} --output=json  | jq '.spec.rules | map(.host == "${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev") | index(true)')
+          EXIST=$(${{ steps.kubectl.outputs.kubectl-path }} get ingress preview-ingress --namespace=${{ env.NAMESPACE }} --output=json  | jq '.spec.rules | map(.host == "${{ inputs.app_name }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev") | index(true)')
 
           # If the preview ingress does not have the host name, add it.
           if [ "$EXIST" == "null" ] 
           then 
             echo "Creating a preview URL."
 
-            ${{ steps.kubectl.outputs.kubectl-path }} patch ingress preview-ingress --namespace=${{ env.NAMESPACE }} --type='json' -p='[ { "op":"add","path":"/spec/rules/-", "value": { "host": "${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev", "http": { "paths": [ { "backend": { "service": { "name": "${{ inputs.app_name }}-${{ steps.letter_case.outputs.kebab }}-preview", "port": { "number": ${{ inputs.port }} } } }, "path": "${{ inputs.path }}", "pathType": "Prefix" } ] } } } ]'
+            ${{ steps.kubectl.outputs.kubectl-path }} patch ingress preview-ingress --namespace=${{ env.NAMESPACE }} --type='json' -p='[ { "op":"add","path":"/spec/rules/-", "value": { "host": "${{ inputs.app_name }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev", "http": { "paths": [ { "backend": { "service": { "name": "${{ inputs.app_name }}-${{ steps.letter_case.outputs.kebab }}-preview", "port": { "number": ${{ inputs.port }} } } }, "path": "${{ inputs.path }}", "pathType": "Prefix" } ] } } } ]'
           else 
             echo "Preview URL already exists. Skipping." 
           fi
@@ -152,7 +152,7 @@ jobs:
         run: |
             # Run curl 20 times with a retry delay of 15 seconds. 
             # For success it will exit with the code 0, and for failure with the code 6.
-            curl --retry 20 --retry-delay 15 --no-buffer --silent --output /dev/null "https://${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev${{ inputs.path }}"
+            curl --retry 20 --retry-delay 15 --no-buffer --silent --output /dev/null "https://${{ inputs.app_name }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev${{ inputs.path }}"
 
       # === Create a GitHub IAT token for the Dignio app.
       # This is kind of stupid because the only reason we're doing
@@ -170,7 +170,7 @@ jobs:
         uses: octokit/request-action@v2.x
         id: create_commit_status
         with:
-          name: "Kubernetes Deploy Preview"
+          name: "${{ inputs.app_name }} deploy preview"
           description: Deploy Preview ready! Click Details to browse to it.
           context: Preview
           owner: dignio
@@ -178,7 +178,7 @@ jobs:
           state: success
           accept: application/vnd.github.v3+json
           route: POST /repos/{owner}/{repo}/statuses/{sha}
-          target_url: https://${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev
+          target_url: https://${{ inputs.app_name }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev
           sha: ${{ github.event.pull_request.head.sha }}
         env:
           GITHUB_TOKEN: ${{ steps.create-iat.outputs.token }}
@@ -226,7 +226,7 @@ jobs:
       - name: Remove the host from the preview ingress
         shell: bash
         run: |
-          INDEX=$(${{ steps.kubectl.outputs.kubectl-path }} get ingress preview-ingress --namespace=${{ env.NAMESPACE }} --output=json  | jq '.spec.rules | map(.host == "${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev") | index(true)')
+          INDEX=$(${{ steps.kubectl.outputs.kubectl-path }} get ingress preview-ingress --namespace=${{ env.NAMESPACE }} --output=json  | jq '.spec.rules | map(.host == "${{ inputs.app_name }}-${{ steps.letter_case.outputs.kebab }}.preview.dignio.dev") | index(true)')
 
           if [ "$INDEX" != "null" ] 
           then 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ jobs:
       app_name: prevent-ui
       service_type: webservice
       port: 80
+      dockerfile: Dockerfile
       docker_build_args: |
         "API_BASE_PATH=https://dev.dignio.com/api"
       path: /

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ jobs:
     uses: dignio/workflows/.github/workflows/deploy-preview.yaml@main
     with:
       app_name: prevent-ui
+      app_name_postfix: storybook
       service_type: webservice
       port: 80
       dockerfile: Dockerfile

--- a/utilities/create-full-app-name.sh
+++ b/utilities/create-full-app-name.sh
@@ -1,0 +1,10 @@
+
+# $1 = app_name
+# $2 = app_name_postfix
+
+full_app_name="$1"
+
+# Prepend the postfix if it exists
+[[ ! -z "$2" ]] && full_app_name+="-$2"
+
+echo "::set-output name=full_name::$full_app_name"


### PR DESCRIPTION
This PR makes it possible to use the preview multiple times in the same repository. The fix is just by adding something called "app_name_postfix" that has to be set if it is going to be used for more than one preview deployment per repository.

If both are using the same app_name
* It would override the docker ECR build
* It can't create an unique url per preview in the kubectl ingress
* It won't be able to create the target_url for the commit status
* Introduce the checkout of this repo so we can use the bash scripts in the utilities folder

This PR introduces the input named `dockerfile`. This just defines the path to the dockerfile if we have to set a different than the default one.

Example from the same repository:

```
  deploy-preview:
    uses: dignio/workflows/.github/workflows/deploy-preview.yaml@v1.2.0
    with:
      app_name: prevent-ui
      service_type: webservice
      port: 80
      docker_build_args: |
        "API_BASE_PATH=https://dev.dignio.com/api"
        "GIT_BRANCH=${{ github.event.pull_request.head.ref }}"
        "GIT_COMMIT=${{ github.event.pull_request.head.sha }}"
        "GIT_TAG=${{ github.event.pull_request.head.ref }}"
  
  storybook-preview:
    uses: dignio/workflows/.github/workflows/deploy-preview.yaml@v1.2.0
    with:
      app_name: prevent-ui
      app_name_postfix: storybook
      service_type: webservice
      port: 80
      dockerfile: Dockerfile.storybook

```

Example URLs where branch is PLAT-451/storybook-preview
```
  prevent-ui-plat-451-storybook-preview.preview.dignio.dev
  prevent-ui-storybook-plat-451-storybook-preview.preview.dignio.dev
 ```
 
 https://dignio.atlassian.net/jira/software/projects/PLAT/boards/63?selectedIssue=PLAT-451