### PR TITLE
PLAT-486: add preview url to outputs

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -53,7 +53,9 @@ on:
         required: true
 
     outputs:
-      preview_url: ${{ jobs.build_push_deploy.outputs.preview_url }}
+      preview_url:
+        description: The full preview URL
+        value: ${{ jobs.build_push_deploy.outputs.preview_url }}
 
 # Predefined environment variables used as default values
 env:

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -52,6 +52,9 @@ on:
         description: The github app private key to be used for the preview link on PR generation
         required: true
 
+    outputs:
+      preview_url: ${{ jobs.build_push_deploy.outputs.preview_url }}
+
 # Predefined environment variables used as default values
 env:
   REGION: eu-north-1
@@ -64,6 +67,9 @@ jobs:
     name: Build and push image to ECR
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
+
+    outputs:
+      preview_url: "https://${{ steps.app_name.outputs.full_name }}.preview.dignio.com"
 
     steps:
       # ===  Check out the current repository

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      preview_url: "https://${{ steps.app_name.outputs.full_name }}.preview.dignio.com"
+      preview_url: "https://${{ steps.app_name.outputs.full_name }}.preview.dignio.dev"
 
     steps:
       # ===  Check out the current repository

--- a/.github/workflows/test-deploy-preview.yaml
+++ b/.github/workflows/test-deploy-preview.yaml
@@ -21,3 +21,12 @@ jobs:
       aws_secret_access_key: ${{ secrets.DEVELOPMENT_GHK8S_AWS_SECRET_KEY_ID }}
       kube_config: ${{ secrets.KUBE_CONFIG_DEV }}
       github_app_private_key: ${{ secrets.DIGNIO_GH_APP_PRIVATE_KEY }}
+
+  check-outputs:
+    name: Check outputs from deploy preview
+    needs: deploy-preview
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo preview URL
+        shell: bash
+        run: echo ${{ jobs.deploy-preview.outputs.preview_url }}

--- a/.github/workflows/test-deploy-preview.yaml
+++ b/.github/workflows/test-deploy-preview.yaml
@@ -29,4 +29,4 @@ jobs:
     steps:
       - name: Echo preview URL
         shell: bash
-        run: echo ${{ jobs.deploy-preview.outputs.preview_url }}
+        run: echo ${{ needs.deploy-preview.outputs.preview_url }}

--- a/.github/workflows/test-deploy-preview.yaml
+++ b/.github/workflows/test-deploy-preview.yaml
@@ -29,4 +29,5 @@ jobs:
     steps:
       - name: Echo preview URL
         shell: bash
-        run: echo ${{ needs.deploy-preview.outputs.preview_url }}
+        run: |
+          [ -z "${{ needs.deploy-preview.outputs.preview_url }}" ] && exit 1 || echo "${{ needs.deploy-preview.outputs.preview_url }}"


### PR DESCRIPTION
We need this in cases we use the preview URL after the job. One example would be cypress runs.

https://dignio.atlassian.net/jira/software/projects/PLAT/boards/63?selectedIssue=PLAT-486