### PR TITLE
PLAT-596: Allow the PR to be merged even though the preview should fail somehow

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -68,6 +68,8 @@ jobs:
   build_push_deploy:
     name: Build and push image to ECR
     if: github.event.action != 'closed'
+    # Prevents a workflow run from failing when a job fails
+    continue-on-error: true
     runs-on: ubuntu-latest
 
     outputs:
@@ -190,6 +192,8 @@ jobs:
   teardown:
     name: Teardown the preview
     if: github.event.action == 'closed'
+    # Prevents a workflow run from failing when a job fails
+    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       # ===  Check out dignio workflow repo for the utilities folder


### PR DESCRIPTION
@weel here you go 🎉 

> Prevents a workflow run from failing when a job fails. Set to true to allow a workflow run to pass when this job fails.
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error