### PR TITLE
fix: do not run the check outputs from deploy preview when the PR is closed

### DIFF
--- a/.github/workflows/test-deploy-preview.yaml
+++ b/.github/workflows/test-deploy-preview.yaml
@@ -25,6 +25,7 @@ jobs:
   check-outputs:
     name: Check outputs from deploy preview
     needs: deploy-preview
+    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     steps:
       - name: Echo preview URL


### PR DESCRIPTION
That job will fail all the time as the teardown process is deleting the preview url , which means it will be empty for this job.