### PR TITLE
PLAT-632: use the new deploy-service which uses the github oidc provider

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -142,7 +142,7 @@ jobs:
           app_name: ${{ steps.app_name.outputs.full_name }}
           service_type: ${{ inputs.service_type }}
           cluster_name: ${{ env.CLUSTER_NAME }}
-          instance: ${{ env.ISNTANCE }}
+          instance: ${{ env.INSTANCE }}
           namespace: ${{ env.NAMESPACE }}
           docker_image: ${{ steps.login-ecr.outputs.registry }}/${{ inputs.app_name }}:${{ env.INSTANCE }}-${{ inputs.app_name_postfix }}-${{ steps.app_name.outputs.full_name }}-${{ steps.short_id.outputs.sha }}
           aws_region: ${{ env.REGION }}

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -16,6 +16,10 @@ on:
         description: This is the application port number.
         required: true
         type: number
+      aws_role:
+        description: The role used to grant access to AWS
+        required: true
+        type: string
 
       # Optional inputs goes here
       app_name_postfix:
@@ -39,15 +43,6 @@ on:
 
     # Secrets
     secrets:
-      aws_access_key_id:
-        description: The AWS access key ID
-        required: true
-      aws_secret_access_key:
-        description: The AWS secret access key
-        required: true
-      kube_config:
-        description: The kube config for deployments
-        required: true
       github_app_private_key:
         description: The github app private key to be used for the preview link on PR generation
         required: true
@@ -63,6 +58,7 @@ env:
   NAMESPACE: preview
   INSTANCE: dev
   UTILITIES: .dignio-workflows/utilities
+  CLUSTER_NAME: dev-k8s
 
 jobs:
   build_push_deploy:
@@ -109,8 +105,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.aws_access_key_id }}
-          aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
+          role-to-assume: ${{ inputs.aws_role }}
+          role-session-name: GithubActionsSession
           aws-region: ${{ env.REGION }}
 
       - name: Login to Amazon ECR
@@ -133,22 +129,18 @@ jobs:
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.INSTANCE }}-${{ inputs.app_name_postfix }}-${{ steps.app_name.outputs.full_name }}-${{ steps.short_id.outputs.sha }}
 
       - name: Deploy the service to Kubernetes
-        uses: dignio/deploy-service@v2
+        uses: dignio/deploy-service@v3
         with:
           app_name: ${{ steps.app_name.outputs.full_name }}
           service_type: ${{ inputs.service_type }}
           namespace: ${{ env.NAMESPACE }}
           docker_image: ${{ steps.login-ecr.outputs.registry }}/${{ inputs.app_name }}:${{ env.INSTANCE }}-${{ inputs.app_name_postfix }}-${{ steps.app_name.outputs.full_name }}-${{ steps.short_id.outputs.sha }}
           aws_region: ${{ env.REGION }}
+          aws_role: ${{ inputs.aws_role }}
           replicas: 1
           port: ${{ inputs.port }}
           container_port: ${{ inputs.port }}
           ingress: false
-
-          # Required secrets
-          AWS_ACCESS_KEY_ID: ${{ secrets.aws_access_key_id }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.aws_secret_access_key }}
-          KUBE_CONFIG: ${{ secrets.kube_config }}
 
       # === This will run a kubectl request to
       # 1. fetch the index of the preview host to check the existence
@@ -218,15 +210,34 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.aws_access_key_id }}
-          aws-secret-access-key: ${{ secrets.aws_secret_access_key }}
+          role-to-assume: ${{ inputs.aws_role }}
+          role-session-name: GithubActionsSession
           aws-region: ${{ env.REGION }}
+
+      - name: Create the kubeconfig
+        id: kubeconfig
+        shell: bash
+        run: |
+          # fetch the aws account id
+          account_id="$(aws sts get-caller-identity --query Account --output text)"
+
+          # By running this command we are fetching the kube configuration for the github oidc user
+          # The OIDC user session is connected to the KubeGithubDeployment role for access to download the configuration
+          # Note, this is a short lived kubeconfig.
+          aws eks update-kubeconfig --name=${{ env.CLUSTER_NAME }} --region=${{ env.REGION }} --role-arn="arn:aws:iam::$account_id:role/KubeGithubDeployment" --kubeconfig=/tmp/kubeconfig
+
+          kubeconfig="$(cat /tmp/kubeconfig)"
+
+          # A hack to add the multiline configuration as an env variable
+          echo "DYNAMIC_KUBECONFIG<<EOF" >> $GITHUB_ENV
+          echo "$kubeconfig" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
 
       - name: Authenticate with Kubernetes
         uses: azure/k8s-set-context@v1
         with:
           method: kubeconfig
-          kubeconfig: ${{ secrets.kube_config }}
+          kubeconfig: ${{ env.DYNAMIC_KUBECONFIG }}
 
       - name: Add kubectl
         uses: azure/setup-kubectl@v2.0

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -52,6 +52,14 @@ on:
         description: The full preview URL
         value: ${{ jobs.build_push_deploy.outputs.preview_url }}
 
+
+# Permissions needed to run this workflow and the actions provided
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
+permissions:
+  id-token: write
+  actions: write
+  contents: read
+
 # Predefined environment variables used as default values
 env:
   REGION: eu-north-1

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -64,7 +64,7 @@ permissions:
 env:
   REGION: eu-north-1
   NAMESPACE: preview
-  INSTANCE: dev
+  INSTANCE: development
   UTILITIES: .dignio-workflows/utilities
   CLUSTER_NAME: dev-k8s
 
@@ -141,6 +141,8 @@ jobs:
         with:
           app_name: ${{ steps.app_name.outputs.full_name }}
           service_type: ${{ inputs.service_type }}
+          cluster_name: ${{ env.CLUSTER_NAME }}
+          instance: ${{ env.ISNTANCE }}
           namespace: ${{ env.NAMESPACE }}
           docker_image: ${{ steps.login-ecr.outputs.registry }}/${{ inputs.app_name }}:${{ env.INSTANCE }}-${{ inputs.app_name_postfix }}-${{ steps.app_name.outputs.full_name }}-${{ steps.short_id.outputs.sha }}
           aws_region: ${{ env.REGION }}
@@ -148,7 +150,6 @@ jobs:
           replicas: 1
           port: ${{ inputs.port }}
           container_port: ${{ inputs.port }}
-          ingress: false
 
       # === This will run a kubectl request to
       # 1. fetch the index of the preview host to check the existence

--- a/.github/workflows/test-deploy-preview.yaml
+++ b/.github/workflows/test-deploy-preview.yaml
@@ -15,11 +15,9 @@ jobs:
       app_name: workflows
       service_type: webservice
       port: 80
+      aws_role: arn:aws:iam::387308402250:role/github_actions_kubernetes_deployment_development
 
     secrets:
-      aws_access_key_id: ${{ secrets.DEVELOPMENT_GHK8S_AWS_ACCESS_KEY_ID }}
-      aws_secret_access_key: ${{ secrets.DEVELOPMENT_GHK8S_AWS_SECRET_KEY_ID }}
-      kube_config: ${{ secrets.KUBE_CONFIG_DEV }}
       github_app_private_key: ${{ secrets.DIGNIO_GH_APP_PRIVATE_KEY }}
 
   check-outputs:

--- a/.github/workflows/test-deploy-preview.yaml
+++ b/.github/workflows/test-deploy-preview.yaml
@@ -14,7 +14,7 @@ jobs:
     with:
       app_name: workflows
       service_type: webservice
-      port: 80
+      port: 3000
       aws_role: arn:aws:iam::387308402250:role/github_actions_kubernetes_deployment_development
 
     secrets:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,32 @@
-FROM nginx:1.16.0-alpine
+FROM node:lts-alpine
 
-COPY index.html /usr/share/nginx/html
+# https://github.com/hexops/dockerfile/blob/main/Dockerfile#L14
+#
+# Non-root user for security purposes.
+#
+RUN addgroup --gid 10001 --system nonroot \
+    && adduser  --uid 10000 --system --ingroup nonroot --home /home/nonroot nonroot
 
-EXPOSE 80
+WORKDIR /home/nonroot/app
 
-CMD ["nginx", "-g", "daemon off;"]
+# Give the nonroot user all rights to the workdir
+RUN chown -R nonroot ./
+
+# Set the user to nonroot before proceeding
+USER nonroot
+
+# Set the global npm package directory
+ENV NPM_CONFIG_PREFIX=/home/nonroot/.npm-global
+# Set the global npm package directory binary folder to PATH
+ENV PATH=$PATH:/home/nonroot/.npm-global/bin
+
+# We use serve as we do not need anything specific for this applications as we
+# put CloudFront as a layer above where we configure what we need of headers.
+# If any configuration is needed, have a look at this page: https://github.com/vercel/serve-handler#options
+RUN npm i -g serve
+
+COPY index.html /home/nonroot/app
+
+EXPOSE 3000
+
+CMD [ "serve", "--no-clipboard", "/home/nonroot/app" ]

--- a/README.md
+++ b/README.md
@@ -21,15 +21,13 @@ jobs:
       app_name: prevent-ui
       app_name_postfix: storybook
       service_type: webservice
+      aws_role: arn:aws:iam::<org_id>:role/github_actions_kubernetes_deployment_development
       port: 80
       dockerfile: Dockerfile
       docker_build_args: |
         "API_BASE_PATH=https://dev.dignio.com/api"
       path: /
     secrets:
-      aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      kube_config: ${{ secrets.KUBE_CONFIG }}
       github_app_private_key: ${{ secrets.GITHUB_APP_PRIVATE_KEY }}
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jobs:
       app_name: prevent-ui
       app_name_postfix: storybook
       service_type: webservice
-      aws_role: arn:aws:iam::<org_id>:role/github_actions_kubernetes_deployment_development
+      aws_role: arn:aws:iam::<account_id>:role/github_actions_kubernetes_deployment_development
       port: 80
       dockerfile: Dockerfile
       docker_build_args: |


### PR DESCRIPTION
* Remove AWS and Kube config from secrets input
* Use role to assume, with a role coming from the repository using this workflow
* Add the logic for the dynamic kube config file to the teardown
* Updated the dockerfile to use nonroot user. (also using serve instead of nginx)