### PR TITLE
PLAT-741: override hostname in previews

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -91,7 +91,7 @@ jobs:
     steps:
       # ===  Check out the current repository
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
 
       # ===  Check out dignio workflow repo for the utilities folder
       - name: Checkout dignio/workflow repository

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -95,7 +95,7 @@ jobs:
 
       # ===  Check out dignio workflow repo for the utilities folder
       - name: Checkout dignio/workflow repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.1
         with:
           ref: PLAT-741-override-hostname-in-previews
           repository: dignio/workflows
@@ -210,7 +210,7 @@ jobs:
     steps:
       # ===  Check out dignio workflow repo for the utilities folder
       - name: Checkout dignio/workflow repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.1
         with:
           ref: PLAT-741-override-hostname-in-previews
           repository: dignio/workflows

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -45,6 +45,10 @@ on:
         required: false
         type: boolean
         default: true
+      override_hostname:
+        description: Allows choosing another hostname for previews. Example- <override_hostname>_previews.dignio.dev
+        required: false
+        type: string
 
     # Secrets
     secrets:
@@ -220,7 +224,7 @@ jobs:
       # === Create the full app name for docker images and manifests
       - name: Create full app name
         id: app_name
-        run: bash ${{ env.UTILITIES }}/create-full-app-name.sh "${{ inputs.app_name }}" "${{ inputs.app_name_postfix }}" "${{ steps.letter_case.outputs.kebab }}"
+        run: bash ${{ env.UTILITIES }}/create-full-app-name.sh "${{ inputs.app_name }}" "${{ inputs.app_name_postfix }}" "${{ inputs.override_hostname }}" "${{ steps.letter_case.outputs.kebab }}"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -97,7 +97,6 @@ jobs:
       - name: Checkout dignio/workflow repository
         uses: actions/checkout@v3
         with:
-          ref: PLAT-741-override-hostname-in-previews
           repository: dignio/workflows
           path: ".dignio-workflows"
 
@@ -212,7 +211,6 @@ jobs:
       - name: Checkout dignio/workflow repository
         uses: actions/checkout@v3
         with:
-          ref: PLAT-741-override-hostname-in-previews
           repository: dignio/workflows
           path: ".dignio-workflows"
 

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -95,7 +95,7 @@ jobs:
 
       # ===  Check out dignio workflow repo for the utilities folder
       - name: Checkout dignio/workflow repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.1
         with:
           repository: dignio/workflows
           path: ".dignio-workflows"
@@ -209,7 +209,7 @@ jobs:
     steps:
       # ===  Check out dignio workflow repo for the utilities folder
       - name: Checkout dignio/workflow repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.0.1
         with:
           repository: dignio/workflows
           path: ".dignio-workflows"

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -91,11 +91,11 @@ jobs:
     steps:
       # ===  Check out the current repository
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@PLAT-741-override-hostname-in-previews
 
       # ===  Check out dignio workflow repo for the utilities folder
       - name: Checkout dignio/workflow repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@PLAT-741-override-hostname-in-previews
         with:
           repository: dignio/workflows
           path: ".dignio-workflows"
@@ -209,7 +209,7 @@ jobs:
     steps:
       # ===  Check out dignio workflow repo for the utilities folder
       - name: Checkout dignio/workflow repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@PLAT-741-override-hostname-in-previews
         with:
           repository: dignio/workflows
           path: ".dignio-workflows"

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -95,8 +95,9 @@ jobs:
 
       # ===  Check out dignio workflow repo for the utilities folder
       - name: Checkout dignio/workflow repository
-        uses: actions/checkout@v3.0.1
+        uses: actions/checkout@v3
         with:
+          ref: PLAT-741-override-hostname-in-previews
           repository: dignio/workflows
           path: ".dignio-workflows"
 
@@ -209,8 +210,9 @@ jobs:
     steps:
       # ===  Check out dignio workflow repo for the utilities folder
       - name: Checkout dignio/workflow repository
-        uses: actions/checkout@v3.0.1
+        uses: actions/checkout@v3
         with:
+          ref: PLAT-741-override-hostname-in-previews
           repository: dignio/workflows
           path: ".dignio-workflows"
 

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -117,7 +117,7 @@ jobs:
       # === Create the full app name for docker images and manifests
       - name: Create full app name
         id: app_name
-        run: bash ${{ env.UTILITIES }}/create-full-app-name.sh "${{ inputs.app_name }}" "${{ inputs.app_name_postfix }}" "${{ steps.letter_case.outputs.kebab }}"
+        run: bash ${{ env.UTILITIES }}/create-full-app-name.sh "${{ inputs.app_name }}" "${{ inputs.app_name_postfix }}" "${{ inputs.override_hostname }}" "${{ steps.letter_case.outputs.kebab }}"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -95,7 +95,7 @@ jobs:
 
       # ===  Check out dignio workflow repo for the utilities folder
       - name: Checkout dignio/workflow repository
-        uses: actions/checkout@v3.0.1
+        uses: actions/checkout@v3
         with:
           ref: PLAT-741-override-hostname-in-previews
           repository: dignio/workflows
@@ -210,7 +210,7 @@ jobs:
     steps:
       # ===  Check out dignio workflow repo for the utilities folder
       - name: Checkout dignio/workflow repository
-        uses: actions/checkout@v3.0.1
+        uses: actions/checkout@v3
         with:
           ref: PLAT-741-override-hostname-in-previews
           repository: dignio/workflows

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -91,11 +91,11 @@ jobs:
     steps:
       # ===  Check out the current repository
       - name: Checkout repository
-        uses: actions/checkout@PLAT-741-override-hostname-in-previews
+        uses: actions/checkout@v3
 
       # ===  Check out dignio workflow repo for the utilities folder
       - name: Checkout dignio/workflow repository
-        uses: actions/checkout@PLAT-741-override-hostname-in-previews
+        uses: actions/checkout@v3
         with:
           repository: dignio/workflows
           path: ".dignio-workflows"
@@ -209,7 +209,7 @@ jobs:
     steps:
       # ===  Check out dignio workflow repo for the utilities folder
       - name: Checkout dignio/workflow repository
-        uses: actions/checkout@PLAT-741-override-hostname-in-previews
+        uses: actions/checkout@v3
         with:
           repository: dignio/workflows
           path: ".dignio-workflows"

--- a/utilities/create-full-app-name.sh
+++ b/utilities/create-full-app-name.sh
@@ -9,7 +9,7 @@ kebab_branch_name=$4
 
 
 
-if [ ! -z "$app_name_postfix" ]
+if [ ! -z "$override_hostname" ]
 then
     full_app_name="$app_name"
     # Prepend the postfix if it exists

--- a/utilities/create-full-app-name.sh
+++ b/utilities/create-full-app-name.sh
@@ -4,18 +4,24 @@ set -euxo pipefail
 
 app_name=$1
 app_name_postfix=$2
-kebab_branch_name=$3
+override_hostname=$3
+kebab_branch_name=$4
 
-full_app_name="$app_name"
 
-# Prepend the postfix if it exists
+
 if [ ! -z "$app_name_postfix" ]
 then
-    full_app_name+="-$app_name_postfix"
+    full_app_name="$app_name"
+    # Prepend the postfix if it exists
+    if [ ! -z "$app_name_postfix" ]
+    then
+        full_app_name+="-$app_name_postfix"
+    fi
+
+    full_app_name+="-$kebab_branch_name"
+else
+    full_app_name="$override_hostname"
 fi
-
-full_app_name+="-$kebab_branch_name"
-
 # Set a limit to 63 characters as k8s has the final say in this.
 # Remove - if that is the last character
 full_app_name="$(echo $full_app_name | cut -c -63 | sed 's/-$//')"

--- a/utilities/create-full-app-name.sh
+++ b/utilities/create-full-app-name.sh
@@ -11,6 +11,8 @@ kebab_branch_name=$4
 
 if [ ! -z "$override_hostname" ]
 then
+    full_app_name="$override_hostname"
+else
     full_app_name="$app_name"
     # Prepend the postfix if it exists
     if [ ! -z "$app_name_postfix" ]
@@ -19,8 +21,6 @@ then
     fi
 
     full_app_name+="-$kebab_branch_name"
-else
-    full_app_name="$override_hostname"
 fi
 # Set a limit to 63 characters as k8s has the final say in this.
 # Remove - if that is the last character


### PR DESCRIPTION
Added support for the overriding of hostname. 

This includes a new variable being added to the [create-full-app-name.sh](https://github.com/dignio/workflows/blob/main/utilities/create-full-app-name.sh) script (and some tuning to the deployment)- if the `override_hostname` variable is presented, then use `override_host_name.previews.dignio.com `as the hostname.