### PR TITLE
DEVEX-356 fix issue with merged pull request

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -54,15 +54,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       preview_url: ${{ steps.print-preview-url.outputs.preview_url }}
-      pr_number: ${{ steps.sanitize_pr_name.outputs.PR_ID }}
-      pr_name: ${{ steps.sanitize_pr_name.outputs.PR_ID }}-${{ steps.repo_name.outputs.REPO_NAME }}
+      pr_name: ${{ github.event.pull_request.number }}-${{ steps.repo_name.outputs.REPO_NAME }}
     steps:
-      - name: Sanitize pull request Name
-        id: sanitize_pr_name
-        shell: bash
-        run: |
-          echo "PR_ID=pr-$(echo "$GITHUB_REF" | awk -F / '{print $3}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
-
       - name: Repository name
         id: repo_name
         shell: bash
@@ -72,7 +65,7 @@ jobs:
       - name: Print preview URL
         id: print-preview-url
         shell: bash
-        run: echo "preview_url=https://${{ steps.sanitize_pr_name.outputs.PR_ID }}-${{ steps.repo_name.outputs.REPO_NAME }}.preview.dignio.dev" >> $GITHUB_OUTPUT
+        run: echo "preview_url=https://${{ github.event.pull_request.number }}-${{ steps.repo_name.outputs.REPO_NAME }}.preview.dignio.dev" >> $GITHUB_OUTPUT
 
   build_and_push:
     runs-on: ubuntu-latest
@@ -109,7 +102,7 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=raw,value=preview-${{ needs.setup.outputs.pr_number }}
+            type=raw,value=preview-${{ github.event.pull_request.number }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -231,9 +224,9 @@ jobs:
         uses: octokit/request-action@v2.x
         id: create_commit_status
         with:
-          name: "${{ needs.setup.outputs.pr_number }} deploy preview"
+          name: "${{ github.event.pull_request.number }} deploy preview"
           description: Deploy Preview ready! Click Details to browse to it.
-          context: "Preview - ${{ needs.setup.outputs.pr_number }}"
+          context: "Preview - ${{ github.event.pull_request.number }}"
           owner: dignio
           repo: ${{ github.event.repository.name }}
           state: success

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       preview_url: ${{ steps.print-preview-url.outputs.preview_url }}
-      pr_name: ${{ github.event.pull_request.number }}-${{ steps.repo_name.outputs.REPO_NAME }}
+      pr_name: "pr-${{ github.event.pull_request.number }}-${{ steps.repo_name.outputs.REPO_NAME }}"
     steps:
       - name: Repository name
         id: repo_name
@@ -65,7 +65,7 @@ jobs:
       - name: Print preview URL
         id: print-preview-url
         shell: bash
-        run: echo "preview_url=https://${{ github.event.pull_request.number }}-${{ steps.repo_name.outputs.REPO_NAME }}.preview.dignio.dev" >> $GITHUB_OUTPUT
+        run: echo "preview_url=https://pr-${{ github.event.pull_request.number }}-${{ steps.repo_name.outputs.REPO_NAME }}.preview.dignio.dev" >> $GITHUB_OUTPUT
 
   build_and_push:
     runs-on: ubuntu-latest
@@ -102,7 +102,7 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=raw,value=preview-${{ github.event.pull_request.number }}
+            type=raw,value=preview-pr-${{ github.event.pull_request.number }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -224,9 +224,9 @@ jobs:
         uses: octokit/request-action@v2.x
         id: create_commit_status
         with:
-          name: "${{ github.event.pull_request.number }} deploy preview"
+          name: "pr-${{ github.event.pull_request.number }} deploy preview"
           description: Deploy Preview ready! Click Details to browse to it.
-          context: "Preview - ${{ github.event.pull_request.number }}"
+          context: "Preview - pr-${{ github.event.pull_request.number }}"
           owner: dignio
           repo: ${{ github.event.repository.name }}
           state: success


### PR DESCRIPTION
There is an issue when merging a pull request, the variable `GITHUB_REF` does not contain the pull request number, which breaks the action that removes all kubernetes objects created in that pull request, so it needs to be replaced with `github.event.pull_request.number`.